### PR TITLE
dockerfile 내 nltk, summary파일 경로 변경

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
 FROM tomcat
-ADD ./docker_files/bin/nltk /usr/local/tomcat/bin/bin/nltk
-ADD ./docker_files/bin/summary /usr/local/tomcat/bin/bin/summary
+ADD ./docker_files/bin/nltk /usr/local/tomcat/bin/nltk
+ADD ./docker_files/bin/summary /usr/local/tomcat/bin/summary
 ADD ./docker_files/nltk_data /root/nltk_data
 ADD ./docker_files/main.py /root/main.py
 RUN apt-get update && apt-get full-upgrade -y && apt-get install python3 -y && apt-get install python3-pip -y


### PR DESCRIPTION
.war파일 내 nltk, summary의 경로와 기존 도커 컨테이너 내 해당 파일들의 경로 상이했음
.war파일 경로로 해당 파일들의 경로를 맞추어 줌